### PR TITLE
build: use ssh for repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openedx/typescript-config.git"
+    "url": "git@github.com:openedx/typescript-config.git"
   },
   "keywords": [
     "typescript",
+    "tsconfig",
+    "open edx",
     "edx"
   ],
   "author": "edX",


### PR DESCRIPTION
Follows the `repository` field in `browserslist-config` ([source](https://github.com/openedx/browserslist-config/blob/19ce2e4fff0c8cd19a47530e245af99cf6c04e11/package.json#L7)).